### PR TITLE
Add a minimalist option that hides elements on the page

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,13 @@ const lowerLat = 1.156,
 const distanceLong = Math.abs(upperLong - lowerLong);
 const distanceLat = Math.abs(upperLat - lowerLat);
 
+const options = {
+  minimalist: 'minimalist'
+}
+
+const urlParams = new URLSearchParams(window.location.search);
+const optionMinimalist = urlParams.get(options.minimalist);
+
 const bboxGeoJSON = polygon([
   [
     [-180, 90],
@@ -627,7 +634,17 @@ const Player = () => {
     </div>
   );
 };
-render(<Player />, document.getElementById('player'));
+
+if (optionMinimalist) {
+  const $elements = [
+    document.getElementsByTagName('HEADER')[0],
+    document.getElementsByClassName('mapboxgl-control-container')[0]
+  ]
+
+  $elements.forEach($elm => $elm.style.display = 'none')
+} else {
+  render(<Player />, document.getElementById('player'));
+}
 
 (async () => {
   await styleDataLoaded;


### PR DESCRIPTION
Hey cheeaun, glad to see that you are still maintaining this project. Loving it!

I'm using this webapp inside my Home Assistant Dashboard and the `Player` would have the most of the map covered on a smaller screen in an `iframe`. This PR added a minimalist option that hides the player and map controls. 

With the change my dashboard looks fantastic on mobile and big screen. Not sure if hiding Mapbox logo is the right thing to do though. Let me know what do you think on this.

![img](https://user-images.githubusercontent.com/64649350/82419198-9ef50200-9ab0-11ea-88b2-b5f14705729c.png)
